### PR TITLE
Improve search by namespace

### DIFF
--- a/provider/galaxy.go
+++ b/provider/galaxy.go
@@ -61,11 +61,9 @@ func (g AnsibleGalaxy) VersionsForRole(ctx context.Context, r requirements.Role)
 	params := url.Values{}
 
 	// namespace to be used to filter the Ansible Galaxy results
-	var namespace string
 	split := strings.Split(keywords, ".")
 	if len(split) > 0 {
-		namespace = split[0]
-		params.Add("namespaces", namespace)
+		params.Add("namespaces", split[0])
 		params.Add("keywords", split[1])
 	} else {
 		params.Add("keywords", keywords)
@@ -124,7 +122,7 @@ func (g AnsibleGalaxy) VersionsForRole(ctx context.Context, r requirements.Role)
 	}
 
 	if matching == nil {
-		return nil, fmt.Errorf("%s: unable to find role in Ansible Galaxy", keywords)
+		return nil, fmt.Errorf("%s: unable to find role in Ansible Galaxy", results)
 	}
 
 	// get the latest version of the role


### PR DESCRIPTION
I'm receiving some errors during the search on ansible galaxy:

```
ERR: unable to find role in Ansible Galaxy: geerlingguy.apache.
ERR: unable to find role in Ansible Galaxy: geerlingguy.nginx.
```
Adding `namespaces` parameter to the URL value could fix the issue in most cases:

```
WARN: geerlingguy.apache: role not at the latest version, upgrade to 3.1.0.
INFO: geerlingguy.nginx: the role is already at the latest version.
```