### PR TITLE
main: suppress the error messages when exiting with CTRL+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ WARN: atosatto.grafana: role not at the latest version, upgrade from v1.0.0 to v
 ```
 
 
-In addition to requirements files, `ansible-requirements-lint` can also parse role dependencies
+In addition to requirements files, `ansible-requirements-lint` can parse role dependencies
 declared in the `meta/main.yml` file in your role directory
 
 ```bash
@@ -68,7 +68,7 @@ dependencies:
   version: v1.0.0
 ```
 
-Running `ansible-requirements-lint` will produce the following results 
+Running `ansible-requirements-lint` will produce the following results
 
 ```bash
 $ ansible-requirements-lint meta/main.yml

--- a/cmd/ansible-requirements-lint/updates.go
+++ b/cmd/ansible-requirements-lint/updates.go
@@ -21,20 +21,23 @@ func runUpdatesLinter(ctx context.Context, r *requirements.Requirements, updates
 	var numUpdatesOrErr = 0
 	for _, role := range r.Roles {
 		rolesChan <- *role
-		result := <-resultsChan
-
-		switch {
-		case result.Level == linter.LevelInfo && *verbose:
-			color.New(color.Bold, color.FgHiCyan).Printf("INFO: ")
-			fmt.Printf("%s.\n", result.Msg)
-		case result.Level == linter.LevelWarning:
-			color.New(color.Bold, color.FgHiYellow).Printf("WARN: ")
-			fmt.Printf("%s.\n", result.Msg)
-			numUpdatesOrErr++
-		case result.Level == linter.LevelError:
-			color.New(color.Bold, color.FgHiRed).Printf("ERR: ")
-			fmt.Printf("%v.\n", result.Err)
-			numUpdatesOrErr++
+		select {
+		case <-ctx.Done():
+			return numUpdatesOrErr
+		case result := <-resultsChan:
+			switch {
+			case result.Level == linter.LevelInfo && *verbose:
+				color.New(color.Bold, color.FgHiCyan).Printf("INFO: ")
+				fmt.Printf("%s.\n", result.Msg)
+			case result.Level == linter.LevelWarning:
+				color.New(color.Bold, color.FgHiYellow).Printf("WARN: ")
+				fmt.Printf("%s.\n", result.Msg)
+				numUpdatesOrErr++
+			case result.Level == linter.LevelError:
+				color.New(color.Bold, color.FgHiRed).Printf("ERR: ")
+				fmt.Printf("%v.\n", result.Err)
+				numUpdatesOrErr++
+			}
 		}
 	}
 


### PR DESCRIPTION
`ansible-requirements-lint` now exits immediately on CTRL+C 

```
± % ansible-requirements-lint requirements.yml                                                                                                                     
WARN: PowerDNS.pdns_recursor: role not at the latest version, upgrade from v1.2.0 to v1.3.2.
^C%
```

instead of printing error messages generated by the context cancellation

```
± % ansible-requirements-lint requirements.yml
WARN: PowerDNS.pdns_recursor: role not at the latest version, upgrade from v1.2.0 to v1.3.2.
^CERR: Get "https://galaxy.ansible.com/api/v1/search/roles/?keywords=PowerDNS.dnsdist": context canceled.
ERR: Get "https://galaxy.ansible.com/api/v1/search/roles/?keywords=atosatto.prometheus": context canceled.
ERR: Get "https://galaxy.ansible.com/api/v1/search/roles/?keywords=atosatto.alertmanager": context canceled.
ERR: Get "https://galaxy.ansible.com/api/v1/search/roles/?keywords=atosatto.grafana": context canceled.
```