### PR TITLE
galaxy: make sure to use the full role name as keyword for the galaxy searches

### DIFF
--- a/linter/updates.go
+++ b/linter/updates.go
@@ -153,7 +153,7 @@ func (u *UpdatesLinter) RunWithContext(ctx context.Context, roles <-chan require
 			results <- Result{
 				Role:     r,
 				Level:    LevelInfo,
-				Msg:      fmt.Sprintf("%s: %s is the latest version for the role, no update needed.", roleName, r.Version),
+				Msg:      fmt.Sprintf("%s: %s is the latest version for the role, no update needed", roleName, r.Version),
 				Metadata: Update{FromVersion: latest, ToVersion: latest, IsUpdate: false},
 			}
 			continue

--- a/requirements/parser.go
+++ b/requirements/parser.go
@@ -54,7 +54,6 @@ func Unmarshal(data []byte) (*Requirements, error) {
 			// - node.Content[1] will contain the list of roles or collections
 			var k, v = childrens[0], childrens[1]
 			childrens = childrens[2:]
-
 			switch {
 			case k.Kind == yaml.ScalarNode && k.Value == "roles":
 				// we are parsing a requirements file using the new
@@ -107,7 +106,6 @@ func parseRolesFromNodesList(nodes []*yaml.Node) ([]*Role, error) {
 
 				var k, v = childrens[0], childrens[1]
 				childrens = childrens[2:]
-
 				switch {
 				case k.Kind == yaml.ScalarNode && k.Value == "src":
 					role.Source = v.Value

--- a/requirements/parser_test.go
+++ b/requirements/parser_test.go
@@ -46,7 +46,7 @@ func parseAndCompare(t *testing.T, requirements string, expected Requirements) {
 func TestParseInlineRequirementsFile(t *testing.T) {
 	var requirements = `
 ---
-# Test ansible-requirements-lint 
+# Test ansible-requirements-lint
 - name: test.ansible-requirements-lint-name
   version: v1.0.0
 
@@ -60,15 +60,15 @@ func TestParseInlineRequirementsFile(t *testing.T) {
 
 	var expected = Requirements{
 		Roles: []*Role{
-			&Role{
+			{
 				Name:    "test.ansible-requirements-lint-name",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-src",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-scm",
 				Version: "v1.0.0",
 				Scm:     "git",
@@ -98,15 +98,15 @@ func TestParseRolesAndCollectionsRequirementsFile(t *testing.T) {
 `
 	var expected = Requirements{
 		Roles: []*Role{
-			&Role{
+			{
 				Name:    "test.ansible-requirements-lint-name",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-src",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-scm",
 				Version: "v1.0.0",
 				Scm:     "git",
@@ -141,22 +141,22 @@ func TestParseMetaRequirementsFile(t *testing.T) {
 `
 	var expected = Requirements{
 		Roles: []*Role{
-			&Role{
+			{
 				Name: "test.ansible-requirements-lint-inline",
 			},
-			&Role{
+			{
 				Name:    "test.ansible-requirements-lint-role",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Name:    "test.ansible-requirements-lint-name",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-src",
 				Version: "v1.0.0",
 			},
-			&Role{
+			{
 				Source:  "test.ansible-requirements-lint-scm",
 				Version: "v1.0.0",
 				Scm:     "git",


### PR DESCRIPTION
This fixes some edge cases in which Ansible galaxy was returning some results for the role even if this was not existing.

For example, `ansible-galaxy-lint` was detecting some updates for the not existing `atosatto.test` role

```
± % cat requirements.yml
---
- name: atosatto.test
  version: v1.0.0

± % ansible-requirements-lint requirements.yml
WARN: atosatto.test: role not at the latest version, upgrade from v1.0.0 to v2.1.0.
```