### PR TITLE
requirements: handle meta/main.yml files with galaxy_info

### DIFF
--- a/requirements/parser.go
+++ b/requirements/parser.go
@@ -70,7 +70,8 @@ func Unmarshal(data []byte) (*Requirements, error) {
 			case k.Kind == yaml.ScalarNode && k.Value == "collections":
 				// collections are not supported yet
 			case k.Kind == yaml.ScalarNode:
-				return nil, NewUnexpectedMappingNodeValueError(k.Line, k.Value)
+				// when parsing dependencies in the meta/main.yml format
+				// we might encounter here the meta specific fields
 			default:
 				return nil, NewUnexpectedNodeKindError(k.Line, k.Kind)
 			}

--- a/requirements/parser_test.go
+++ b/requirements/parser_test.go
@@ -122,6 +122,9 @@ func TestParseRolesAndCollectionsRequirementsFile(t *testing.T) {
 func TestParseMetaRequirementsFile(t *testing.T) {
 	var requirements = `
 ---
+  galaxy_info:
+    description: Test Parse Meta Requirements File
+
   dependencies:
   - test.ansible-requirements-lint-inline
 


### PR DESCRIPTION
The parser is failing when `meta/main.yml` contains `galaxy_info` definitions.